### PR TITLE
Fix ai-orchestrator env loading

### DIFF
--- a/ai-orchestrator/app/core/config.py
+++ b/ai-orchestrator/app/core/config.py
@@ -1,5 +1,12 @@
 # app/core/config.py
 import os
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+
+# Load service-local .env regardless of the process working directory.
+load_dotenv(Path(__file__).resolve().parents[2] / ".env")
 
 # 디버그 모드 (True일 경우 상세 로그 및 사유 반환)
 DEBUG = os.getenv("DEBUG", "false").lower() == "true"


### PR DESCRIPTION
## Summary
- load ai-orchestrator/.env from the service directory instead of relying on the process working directory
- make chatbot backpressure settings such as CHATBOT_MAX_CONCURRENCY and CHATBOT_QUEUE_WAIT_SECONDS actually apply at runtime

## Why
The orchestrator config was falling back to code defaults (CHATBOT_MAX_CONCURRENCY=1, CHATBOT_QUEUE_WAIT_SECONDS=1.0) when started without exported env vars. That caused concurrent chatbot requests to hit 429 CHATBOT_OVERLOADED even though .env was configured with higher limits.

## Verification
- imported app.core.config from ai-orchestrator and confirmed the loaded values changed from defaults to the .env values in the local workspace
